### PR TITLE
Refactor Dockerfiles, suppress nvidia-smi output, and add target to model table

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,9 +20,6 @@ COPY --from=0 /usr/local/cuda/lib64/libcudart.so.12 /usr/lib/x86_64-linux-gnu
 COPY --from=0 /srv/llama.cpp/main /usr/local/bin/llama
 COPY --from=0 /srv/llama.cpp/server /usr/local/bin/llama-server
 
-# copy entrypoint script
-COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
-
 # create llama user and set home directory
 RUN useradd --system --create-home llama
 
@@ -31,5 +28,8 @@ USER llama
 WORKDIR /home/llama
 
 EXPOSE 8080
+
+# copy and set entrypoint script
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 
 ENTRYPOINT [ "/usr/local/bin/docker-entrypoint.sh" ]

--- a/Dockerfile-cpu
+++ b/Dockerfile-cpu
@@ -15,9 +15,6 @@ FROM debian:12-slim AS env-deploy
 COPY --from=0 /srv/llama.cpp/main /usr/local/bin/llama
 COPY --from=0 /srv/llama.cpp/server /usr/local/bin/llama-server
 
-# copy entrypoint script
-COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
-
 # create llama user and set home directory
 RUN useradd --system --create-home llama
 
@@ -26,5 +23,8 @@ USER llama
 WORKDIR /home/llama
 
 EXPOSE 8080
+
+# copy and set entrypoint script
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 
 ENTRYPOINT [ "/usr/local/bin/docker-entrypoint.sh" ]

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 USE_SUDO := $(shell which docker >/dev/null && docker ps 2>&1 | grep -q "permission denied" && echo sudo)
 DOCKER := $(if $(USE_SUDO), sudo docker, docker)
 DIRNAME := $(notdir $(CURDIR))
-HAS_NVIDIA_GPU := $(shell nvidia-smi --query --display=COMPUTE && echo ok)
+HAS_NVIDIA_GPU := $(shell which nvidia-smi >/dev/null && nvidia-smi --query --display=COMPUTE && echo ok)
 
 build:
 ifdef HAS_NVIDIA_GPU

--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ default, these will download the `_Q5_K_M.gguf` versions of the models. These
 models are quantized to 5 bits which provide a good balance between speed and
 accuracy.
 
-| Model | Model Size | (V)RAM Required | [~Score](https://huggingface.co/spaces/HuggingFaceH4/open_llm_leaderboard) |
-| --- | --- | --- | --- |
-| [`llama-2-13b-chat`](https://huggingface.co/TheBloke/Llama-2-13B-chat-GGUF) | 13B | 11.73 GB | 53.26 |
-| [`mistral-7b-instruct-v0.2`](https://huggingface.co/TheBloke/Mistral-7B-Instruct-v0.2-GGUF) | 7B | 7.63 GB | 65.71 |
-| [`solar-10.7b-instruct-v1.0`](https://huggingface.co/TheBloke/SOLAR-10.7B-Instruct-v1.0-GGUF) | 10.7B | 10.10 GB | 74.2 |
+| Target | Model | Model Size | (V)RAM Required | [~Score](https://huggingface.co/spaces/HuggingFaceH4/open_llm_leaderboard) |
+| --- | --- | --- | --- | --- |
+| llama-2-13b | [`llama-2-13b-chat`](https://huggingface.co/TheBloke/Llama-2-13B-chat-GGUF) | 13B | 11.73 GB | 53.26 |
+| mistral-7b | [`mistral-7b-instruct-v0.2`](https://huggingface.co/TheBloke/Mistral-7B-Instruct-v0.2-GGUF) | 7B | 7.63 GB | 65.71 |
+| solar-10b | [`solar-10.7b-instruct-v1.0`](https://huggingface.co/TheBloke/SOLAR-10.7B-Instruct-v1.0-GGUF) | 10.7B | 10.10 GB | 74.2 |


### PR DESCRIPTION
- Improve Docker caching by moving docker-entrypoint.sh to bottom of Dockerfile
- Only build for GPU if nvidia-smi output is found
- Add Makefile target as a column in model table