### PR TITLE
Use Clang instead of GCC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [v1.4.0](https://github.com/fboulnois/llama-cpp-docker/compare/v1.3.1...v1.4.0) - 2024-03-05
+
+### Fixed
+
+* Use clang 16 instead of gcc in cpu version
+
 ## [v1.3.1](https://github.com/fboulnois/llama-cpp-docker/compare/v1.3.0...v1.3.1) - 2024-01-06
 
 ### Changed

--- a/Dockerfile-cpu
+++ b/Dockerfile-cpu
@@ -3,11 +3,11 @@ FROM debian:12-slim AS env-build
 WORKDIR /srv
 
 # install build tools and clone and compile llama.cpp
-RUN apt-get update && apt-get install -y build-essential git
+RUN apt-get update && apt-get install -y make git clang-16
 
 RUN git clone https://github.com/ggerganov/llama.cpp.git \
   && cd llama.cpp \
-  && make -j
+  && make -j CC=clang-16 CXX=clang++-16
 
 FROM debian:12-slim AS env-deploy
 


### PR DESCRIPTION
On ARM-based MacBooks, GCC does not correctly detect the target ARM processor and thus miscompiles certain instructions which ultimately breaks the build. To work around this issue, use Clang 16 instead of GCC in the CPU version of the build.