### PR TITLE
Add OpenMP libraries to builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [v1.7.0](https://github.com/fboulnois/llama-cpp-docker/compare/v1.6.1...v1.7.0) - 2024-06-12
+
+### Added
+
+* Update nvidia/cuda to 12.5.0
+
+### Fixed
+
+* Add libomp to clang build
+* Add libgomp to cuda build
+* LLAMA_CUBLAS is deprecated
+
 ## [v1.6.1](https://github.com/fboulnois/llama-cpp-docker/compare/v1.6.0...v1.6.1) - 2024-05-21
 
 ### Fixed

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM nvidia/cuda:12.5.0-devel-ubuntu22.04 AS env-build
 WORKDIR /srv
 
 # install build tools and clone and compile llama.cpp
-RUN apt-get update && apt-get install -y build-essential git
+RUN apt-get update && apt-get install -y build-essential git libgomp1
 
 RUN git clone https://github.com/ggerganov/llama.cpp.git \
   && cd llama.cpp \
@@ -11,10 +11,12 @@ RUN git clone https://github.com/ggerganov/llama.cpp.git \
 
 FROM debian:12-slim AS env-deploy
 
-# copy cuda libraries
-COPY --from=0 /usr/local/cuda/lib64/libcublas.so.12 /usr/lib/x86_64-linux-gnu
-COPY --from=0 /usr/local/cuda/lib64/libcublasLt.so.12 /usr/lib/x86_64-linux-gnu
-COPY --from=0 /usr/local/cuda/lib64/libcudart.so.12 /usr/lib/x86_64-linux-gnu
+# copy openmp and cuda libraries
+ENV LD_LIBRARY_PATH=/usr/local/lib
+COPY --from=0 /usr/lib/x86_64-linux-gnu/libgomp.so.1 ${LD_LIBRARY_PATH}/libgomp.so.1
+COPY --from=0 /usr/local/cuda/lib64/libcublas.so.12 ${LD_LIBRARY_PATH}/libcublas.so.12
+COPY --from=0 /usr/local/cuda/lib64/libcublasLt.so.12 ${LD_LIBRARY_PATH}/libcublasLt.so.12
+COPY --from=0 /usr/local/cuda/lib64/libcudart.so.12 ${LD_LIBRARY_PATH}/libcudart.so.12
 
 # copy llama.cpp binaries
 COPY --from=0 /srv/llama.cpp/main /usr/local/bin/llama

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update && apt-get install -y build-essential git
 
 RUN git clone https://github.com/ggerganov/llama.cpp.git \
   && cd llama.cpp \
-  && make -j LLAMA_CUBLAS=1 CUDA_DOCKER_ARCH=all
+  && make -j LLAMA_CUDA=1 CUDA_DOCKER_ARCH=all
 
 FROM debian:12-slim AS env-deploy
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:12.4.1-devel-ubuntu22.04 AS env-build
+FROM nvidia/cuda:12.5.0-devel-ubuntu22.04 AS env-build
 
 WORKDIR /srv
 

--- a/Dockerfile-cpu
+++ b/Dockerfile-cpu
@@ -3,13 +3,17 @@ FROM debian:12-slim AS env-build
 WORKDIR /srv
 
 # install build tools and clone and compile llama.cpp
-RUN apt-get update && apt-get install -y make git clang-16
+RUN apt-get update && apt-get install -y make git clang-16 libomp-16-dev
 
 RUN git clone https://github.com/ggerganov/llama.cpp.git \
   && cd llama.cpp \
   && make -j CC=clang-16 CXX=clang++-16
 
 FROM debian:12-slim AS env-deploy
+
+# copy openmp libraries
+ENV LD_LIBRARY_PATH=/usr/local/lib
+COPY --from=0 /usr/lib/llvm-16/lib/libomp.so.5 ${LD_LIBRARY_PATH}/libomp.so.5
 
 # copy llama.cpp binaries
 COPY --from=0 /srv/llama.cpp/main /usr/local/bin/llama


### PR DESCRIPTION
Install and copy the corresponding OpenMP libraries to the CUDA and Clang containers. This fixes a missing dependency in newer `llama.cpp` builds which require OpenMP. Also makes a few other improvements:

* Updates the `nvidia/cuda` base image to 12.5.0
* Deprecate `LLAMA_CUBLAS` in favor of `LLAMA_CUDA` on newer `llama.cpp` builds

Fixes #8 , closes #9 