### PR TITLE
Fix COPY issue with stale binary names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [v1.7.1](https://github.com/fboulnois/llama-cpp-docker/compare/v1.7.0...v1.7.1) - 2024-06-13
+
+### Fixed
+
+* Copy over new binary names
+
 ## [v1.7.0](https://github.com/fboulnois/llama-cpp-docker/compare/v1.6.1...v1.7.0) - 2024-06-12
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,8 @@ COPY --from=0 /usr/local/cuda/lib64/libcublasLt.so.12 ${LD_LIBRARY_PATH}/libcubl
 COPY --from=0 /usr/local/cuda/lib64/libcudart.so.12 ${LD_LIBRARY_PATH}/libcudart.so.12
 
 # copy llama.cpp binaries
-COPY --from=0 /srv/llama.cpp/main /usr/local/bin/llama
-COPY --from=0 /srv/llama.cpp/server /usr/local/bin/llama-server
+COPY --from=0 /srv/llama.cpp/llama-cli /usr/local/bin/llama-cli
+COPY --from=0 /srv/llama.cpp/llama-server /usr/local/bin/llama-server
 
 # create llama user and set home directory
 RUN useradd --system --create-home llama

--- a/Dockerfile-cpu
+++ b/Dockerfile-cpu
@@ -16,8 +16,8 @@ ENV LD_LIBRARY_PATH=/usr/local/lib
 COPY --from=0 /usr/lib/llvm-16/lib/libomp.so.5 ${LD_LIBRARY_PATH}/libomp.so.5
 
 # copy llama.cpp binaries
-COPY --from=0 /srv/llama.cpp/main /usr/local/bin/llama
-COPY --from=0 /srv/llama.cpp/server /usr/local/bin/llama-server
+COPY --from=0 /srv/llama.cpp/llama-cli /usr/local/bin/llama-cli
+COPY --from=0 /srv/llama.cpp/llama-server /usr/local/bin/llama-server
 
 # create llama user and set home directory
 RUN useradd --system --create-home llama


### PR DESCRIPTION
Shortly before yesterday's updates, the `llama.cpp` project renamed all their binary names which cause the `COPY` steps to fail. Copy over the new binary names.

Fixes #11 