### PR TITLE
Model download improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [v1.8.0](https://github.com/fboulnois/llama-cpp-docker/compare/v1.7.1...v1.8.0) - 2024-08-11
+
+### Added
+
+* Set llama 3.1 as default llama 3 target
+* Add more detailed command line usage
+* Add llama 3.1 8b model
+* Add phi 3 medium and gemma 2 9b and 27b
+* Update nvidia/cuda to 12.5.1
+
+### Changed
+
+* Add pattern rule to download models
+* Move shell into functions
+* Simplify adding new models
+
 ## [v1.7.1](https://github.com/fboulnois/llama-cpp-docker/compare/v1.7.0...v1.7.1) - 2024-06-13
 
 ### Fixed

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:12.5.0-devel-ubuntu22.04 AS env-build
+FROM nvidia/cuda:12.5.1-devel-ubuntu22.04 AS env-build
 
 WORKDIR /srv
 

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,15 @@ llama-3-8b:
 phi-3-mini:
 	cd models && ../docker-entrypoint.sh $@
 
+phi-3-medium:
+	cd models && ../docker-entrypoint.sh $@
+
+gemma-2-9b:
+	cd models && ../docker-entrypoint.sh $@
+
+gemma-2-27b:
+	cd models && ../docker-entrypoint.sh $@
+
 up:
 ifdef HAS_NVIDIA_GPU
 	$(DOCKER) compose -f docker-compose.yml -f docker-compose.gpu.yml up

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,9 @@ command-r:
 llama-3-8b:
 	cd models && ../docker-entrypoint.sh $@
 
+llama-3.1-8b:
+	cd models && ../docker-entrypoint.sh $@
+
 phi-3-mini:
 	cd models && ../docker-entrypoint.sh $@
 

--- a/Makefile
+++ b/Makefile
@@ -10,39 +10,6 @@ else
 	$(DOCKER) build . --file Dockerfile-cpu --tag $(DIRNAME)
 endif
 
-llama-2-13b:
-	cd models && ../docker-entrypoint.sh $@
-
-mistral-7b:
-	cd models && ../docker-entrypoint.sh $@
-
-solar-10b:
-	cd models && ../docker-entrypoint.sh $@
-
-starling-7b:
-	cd models && ../docker-entrypoint.sh $@
-
-command-r:
-	cd models && ../docker-entrypoint.sh $@
-
-llama-3-8b:
-	cd models && ../docker-entrypoint.sh $@
-
-llama-3.1-8b:
-	cd models && ../docker-entrypoint.sh $@
-
-phi-3-mini:
-	cd models && ../docker-entrypoint.sh $@
-
-phi-3-medium:
-	cd models && ../docker-entrypoint.sh $@
-
-gemma-2-9b:
-	cd models && ../docker-entrypoint.sh $@
-
-gemma-2-27b:
-	cd models && ../docker-entrypoint.sh $@
-
 up:
 ifdef HAS_NVIDIA_GPU
 	$(DOCKER) compose -f docker-compose.yml -f docker-compose.gpu.yml up
@@ -52,3 +19,6 @@ endif
 
 down:
 	$(DOCKER) compose down
+
+%:
+	cd models && ../docker-entrypoint.sh $@

--- a/README.md
+++ b/README.md
@@ -36,9 +36,12 @@ for the complete list of server options.
 
 ## Models
 
-The [Makefile](Makefile) has targets for downloading popular models. By default,
-these will download the `_Q5_K_M.gguf` versions of the models. These models are
-quantized to 5 bits which provide a good balance between speed and accuracy.
+The [`docker-entrypoint.sh`](docker-entrypoint.sh) has targets for downloading
+popular models. Run `./docker-entrypoint.sh --help` to list available models.
+Download models by running `./docker-entrypoint.sh <model>` or `make <model>`
+where `<model>` is the name of the model. By default, these will download the
+`_Q5_K_M.gguf` versions of the models. These models are quantized to 5 bits
+which provide a good balance between speed and accuracy.
 
 | Target | Model | Model Size | (V)RAM Required | [~Score](https://huggingface.co/spaces/HuggingFaceH4/open_llm_leaderboard) | [~ELO](https://chat.lmsys.org/?leaderboard) | Notes |
 | --- | --- | --- | --- | --- | --- | --- |

--- a/README.md
+++ b/README.md
@@ -43,12 +43,14 @@ where `<model>` is the name of the model. By default, these will download the
 `_Q5_K_M.gguf` versions of the models. These models are quantized to 5 bits
 which provide a good balance between speed and accuracy.
 
-| Target | Model | Model Size | (V)RAM Required | [~Score](https://huggingface.co/spaces/HuggingFaceH4/open_llm_leaderboard) | [~ELO](https://chat.lmsys.org/?leaderboard) | Notes |
+Confused about which model to use? Below is a list of popular models, ranked by
+[ELO rating](https://en.wikipedia.org/wiki/Elo_rating_system). Generally, the
+higher the ELO rating the better the model.
+
+| Target | Model | Parameters | Size | [~Score](https://huggingface.co/spaces/HuggingFaceH4/open_llm_leaderboard) | [~ELO](https://chat.lmsys.org/?leaderboard) | Notes |
 | --- | --- | --- | --- | --- | --- | --- |
-| llama-2-13b | [`llama-2-13b-chat`](https://huggingface.co/TheBloke/Llama-2-13B-chat-GGUF) | 13B | 11.73 GB | 55.69 | 1067 | The original open LLM |
-| solar-10b | [`solar-10.7b-instruct-v1.0`](https://huggingface.co/TheBloke/SOLAR-10.7B-Instruct-v1.0-GGUF) | 10.7B | 10.10 GB | 74.20 | 1066 | Scores highly on Huggingface |
-| phi-3-mini | [`phi-3-mini`](https://huggingface.co/bartowski/Phi-3-mini-4k-instruct-GGUF) | 3B | 3.13 GB | 69.91 | 1074 | The current best tiny model |
-| mistral-7b | [`mistral-7b-instruct-v0.2`](https://huggingface.co/TheBloke/Mistral-7B-Instruct-v0.2-GGUF) | 7B | 7.63 GB | 65.71 | 1074 | The most popular 7B model |
-| starling-7b | [`starling-lm-7b-beta`](https://huggingface.co/bartowski/Starling-LM-7B-beta-GGUF) | 7B | 5.13 GB | 69.88 | 1118 | Scores highly on Huggingface |
-| command-r | [`c4ai-command-r-v01`](https://huggingface.co/bartowski/c4ai-command-r-v01-GGUF) | 35B | 25.00 GB | 68.54 | 1149 | The current best medium model |
-| llama-3-8b | [`meta-llama-3-8b-instruct`](https://huggingface.co/bartowski/Meta-Llama-3-8B-Instruct-GGUF) | 8B | 5.73 GB | 62.55 | 1154 | The current best small model |
+| gemma-2-9b | [`gemma-2-9b-it`](https://huggingface.co/bartowski/gemma-2-9b-it-GGUF) | 9B | 6.65 GB | 28.90 | 1187 | Google's best small model |
+| llama-3-8b | [`meta-llama-3.1-8b-instruct`](https://huggingface.co/bartowski/Meta-Llama-3.1-8B-Instruct-GGUF) | 8B | 5.73 GB | 26.59 | 1162 | The overall best small model |
+| mistral-7b | [`mistral-7b-instruct-v0.2`](https://huggingface.co/TheBloke/Mistral-7B-Instruct-v0.2-GGUF) | 7B | 5.13 GB | 18.44 | 1072 | The most popular 7B model |
+| phi-3-mini | [`phi-3-mini-4k-instruct`](https://huggingface.co/bartowski/Phi-3-mini-4k-instruct-GGUF) | 3B | 3.13 GB | 25.97 | 1066 | The current best tiny model |
+| llama-2-13b | [`llama-2-13b-chat`](https://huggingface.co/TheBloke/Llama-2-13B-chat-GGUF) | 13B | 9.23 GB | 11.00 | 1063 | The original open LLM |

--- a/README.md
+++ b/README.md
@@ -36,10 +36,9 @@ for the complete list of server options.
 
 ## Models
 
-The [Makefile](Makefile) has a few targets for downloading popular models. By
-default, these will download the `_Q5_K_M.gguf` versions of the models. These
-models are quantized to 5 bits which provide a good balance between speed and
-accuracy.
+The [Makefile](Makefile) has targets for downloading popular models. By default,
+these will download the `_Q5_K_M.gguf` versions of the models. These models are
+quantized to 5 bits which provide a good balance between speed and accuracy.
 
 | Target | Model | Model Size | (V)RAM Required | [~Score](https://huggingface.co/spaces/HuggingFaceH4/open_llm_leaderboard) | [~ELO](https://chat.lmsys.org/?leaderboard) | Notes |
 | --- | --- | --- | --- | --- | --- | --- |

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -18,12 +18,27 @@ gemma-2-27b fbefa7ddf24b32dee231c40e0bdd55f9a3ef0e64c8559b0cb48b66cce66fe671 htt
 EOF
 )
 
+usage() {
+    MODEL_NAMES=$(echo "$MODEL_LIST" | awk '{print "  " $1}')
+    cat << EOF
+Usage: $0 [MODEL]...
+Run llama-server or download a model and exit
+
+If no MODEL is provided, run llama-server with default settings.
+
+Available models to download:
+
+$MODEL_NAMES
+
+EOF
+}
+
 parse_args_download_model() {
-    if [ "$#" -eq 1 ]; then
+    if [ "$#" -ge 1 ]; then
         MODEL_LINE=$(echo "$MODEL_LIST" | grep "$1" || true)
 
-        if [ -z "$MODEL_LINE" ]; then
-            echo "$MODEL_LIST" | awk '{print $1}' | tr '\n' '|' | sed 's/|$//' | xargs printf "$0 [%s]\n"
+        if [ "$1" = "--help" ] || [ -z "$MODEL_LINE" ]; then
+            usage
             exit 1
         fi
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -19,8 +19,8 @@ EOF
 )
 
 usage() {
-    MODEL_NAMES=$(echo "$MODEL_LIST" | awk '{print "  " $1}')
-    cat << EOF
+  MODEL_NAMES=$(echo "$MODEL_LIST" | awk '{print "  " $1}')
+  cat << EOF
 Usage: $0 [MODEL]...
 Run llama-server or download a model and exit
 
@@ -34,49 +34,49 @@ EOF
 }
 
 parse_args_download_model() {
-    if [ "$#" -ge 1 ]; then
-        MODEL_LINE=$(echo "$MODEL_LIST" | grep "$1" || true)
+  if [ "$#" -ge 1 ]; then
+    MODEL_LINE=$(echo "$MODEL_LIST" | grep "$1" || true)
 
-        if [ "$1" = "--help" ] || [ -z "$MODEL_LINE" ]; then
-            usage
-            exit 1
-        fi
-
-        MODEL_SHA256=$(echo "$MODEL_LINE" | awk '{print $2}')
-        MODEL_URL=$(echo "$MODEL_LINE" | awk '{print $3}')
-        MODEL_NAME=$(basename "$MODEL_URL")
-
-        curl -LO "$MODEL_URL"
-        echo "$MODEL_SHA256  $MODEL_NAME" | sha256sum -c -
-        exit 0
+    if [ "$1" = "--help" ] || [ -z "$MODEL_LINE" ]; then
+      usage
+      exit 1
     fi
+
+    MODEL_SHA256=$(echo "$MODEL_LINE" | awk '{print $2}')
+    MODEL_URL=$(echo "$MODEL_LINE" | awk '{print $3}')
+    MODEL_NAME=$(basename "$MODEL_URL")
+
+    curl -LO "$MODEL_URL"
+    echo "$MODEL_SHA256  $MODEL_NAME" | sha256sum -c -
+    exit 0
+  fi
 }
 
 set_default_env_vars() {
-    if [ -z ${LLAMA_HOST+x} ]; then
-        export LLAMA_HOST="0.0.0.0"
-    fi
-    if [ -z ${LLAMA_MODEL+x} ]; then
-        export LLAMA_MODEL="/models/llama-2-13b-chat.Q5_K_M.gguf"
-    fi
+  if [ -z ${LLAMA_HOST+x} ]; then
+    export LLAMA_HOST="0.0.0.0"
+  fi
+  if [ -z ${LLAMA_MODEL+x} ]; then
+    export LLAMA_MODEL="/models/llama-2-13b-chat.Q5_K_M.gguf"
+  fi
 }
 
 convert_llama_env_vars() {
-    LLAMA_ARGS=$(env | grep LLAMA_ | awk '{
-        # for each environment variable
-        for (n = 1; n <= NF; n++) {
-            # replace LLAMA_ prefix with --
-            sub("^LLAMA_", "--", $n)
-            # find first = and split into argument name and value
-            eq = index($n, "=")
-            s1 = tolower(substr($n, 1, eq - 1))
-            s2 = substr($n, eq + 1)
-            # replace _ with - in argument name
-            gsub("_", "-", s1)
-            # print argument name and value
-            print s1 " " s2
-        }
-    }')
+  LLAMA_ARGS=$(env | grep LLAMA_ | awk '{
+    # for each environment variable
+    for (n = 1; n <= NF; n++) {
+      # replace LLAMA_ prefix with --
+      sub("^LLAMA_", "--", $n)
+      # find first = and split into argument name and value
+      eq = index($n, "=")
+      s1 = tolower(substr($n, 1, eq - 1))
+      s2 = substr($n, eq + 1)
+      # replace _ with - in argument name
+      gsub("_", "-", s1)
+      # print argument name and value
+      print s1 " " s2
+    }
+  }')
 }
 
 parse_args_download_model "$@"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -9,8 +9,7 @@ mistral-7b b85cdd596ddd76f3194047b9108a73c74d77ba04bef49255a50fc0cfbda83d32 http
 solar-10b 4ade240f5dcc253272158f3659a56f5b1da8405510707476d23a7df943aa35f7 https://huggingface.co/TheBloke/SOLAR-10.7B-Instruct-v1.0-GGUF/resolve/main/solar-10.7b-instruct-v1.0.Q5_K_M.gguf
 starling-7b c67b033bff47e7b8574491c6c296c094e819488d146aca1c6326c10257450b99 https://huggingface.co/bartowski/Starling-LM-7B-beta-GGUF/resolve/main/Starling-LM-7B-beta-Q5_K_M.gguf
 command-r 1a59aeb034b64e430d25bc9f2b29d9f2cc658af38670fae36226585603da8ecc https://huggingface.co/bartowski/c4ai-command-r-v01-GGUF/resolve/main/c4ai-command-r-v01-Q5_K_M.gguf
-llama-3-8b 16d824ee771e0e33b762bb3dc3232b972ac8dce4d2d449128fca5081962a1a9e https://huggingface.co/bartowski/Meta-Llama-3-8B-Instruct-GGUF/resolve/main/Meta-Llama-3-8B-Instruct-Q5_K_M.gguf
-llama-3.1-8b 14e10feba0c82a55da198dcd69d137206ad22d116a809926d27fa5f2398c69c7 https://huggingface.co/bartowski/Meta-Llama-3.1-8B-Instruct-GGUF/resolve/main/Meta-Llama-3.1-8B-Instruct-Q5_K_M.gguf
+llama-3-8b 14e10feba0c82a55da198dcd69d137206ad22d116a809926d27fa5f2398c69c7 https://huggingface.co/bartowski/Meta-Llama-3.1-8B-Instruct-GGUF/resolve/main/Meta-Llama-3.1-8B-Instruct-Q5_K_M.gguf
 phi-3-mini 597a483b0e56360cb488d3f8a5ec0fd2c3a3eb44da7bb69020b79ba7c1f6ce85 https://huggingface.co/bartowski/Phi-3-mini-4k-instruct-GGUF/resolve/main/Phi-3-mini-4k-instruct-Q6_K.gguf
 phi-3-medium 5e9d850d6c899e7fdf39a19cdf6fecae225e0c5bb3d13d6f277cbda508a15f0c https://huggingface.co/bartowski/Phi-3-medium-4k-instruct-GGUF/resolve/main/Phi-3-medium-4k-instruct-Q5_K_M.gguf
 gemma-2-9b a4b0b55ce809a09baaefb789b0046ac77ecd502aba8aeb2ed63cc237d9f40ce7 https://huggingface.co/bartowski/gemma-2-9b-it-GGUF/resolve/main/gemma-2-9b-it-Q5_K_M.gguf

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -25,8 +25,17 @@ if [ "$#" -eq 1 ]; then
     elif [ "$1" = "phi-3-mini" ]; then
         MODEL_URL="https://huggingface.co/bartowski/Phi-3-mini-4k-instruct-GGUF/resolve/main/Phi-3-mini-4k-instruct-Q6_K.gguf"
         MODEL_SHA256="597a483b0e56360cb488d3f8a5ec0fd2c3a3eb44da7bb69020b79ba7c1f6ce85"
+    elif [ "$1" = "phi-3-medium" ]; then
+        MODEL_URL="https://huggingface.co/bartowski/Phi-3-medium-4k-instruct-GGUF/resolve/main/Phi-3-medium-4k-instruct-Q5_K_M.gguf"
+        MODEL_SHA256="5e9d850d6c899e7fdf39a19cdf6fecae225e0c5bb3d13d6f277cbda508a15f0c"
+    elif [ "$1" = "gemma-2-9b" ]; then
+        MODEL_URL="https://huggingface.co/bartowski/gemma-2-9b-it-GGUF/resolve/main/gemma-2-9b-it-Q5_K_M.gguf"
+        MODEL_SHA256="a4b0b55ce809a09baaefb789b0046ac77ecd502aba8aeb2ed63cc237d9f40ce7"
+    elif [ "$1" = "gemma-2-27b" ]; then
+        MODEL_URL="https://huggingface.co/bartowski/gemma-2-27b-it-GGUF/resolve/main/gemma-2-27b-it-Q5_K_M.gguf"
+        MODEL_SHA256="fbefa7ddf24b32dee231c40e0bdd55f9a3ef0e64c8559b0cb48b66cce66fe671"
     else
-        echo "$0 [llama-2-13b|mistral-7b|solar-10b|starling-7b|command-r|llama-3-8b|phi-3-mini]"
+        echo "$0 [llama-2-13b|mistral-7b|solar-10b|starling-7b|command-r|llama-3-8b|phi-3-mini|phi-3-medium|gemma-2-9b|gemma-2-27b]"
         exit 1
     fi
     MODEL_NAME=$(basename "$MODEL_URL")

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -22,6 +22,9 @@ if [ "$#" -eq 1 ]; then
     elif [ "$1" = "llama-3-8b" ]; then
         MODEL_URL="https://huggingface.co/bartowski/Meta-Llama-3-8B-Instruct-GGUF/resolve/main/Meta-Llama-3-8B-Instruct-Q5_K_M.gguf"
         MODEL_SHA256="16d824ee771e0e33b762bb3dc3232b972ac8dce4d2d449128fca5081962a1a9e"
+    elif [ "$1" = "llama-3.1-8b" ]; then
+        MODEL_URL="https://huggingface.co/bartowski/Meta-Llama-3.1-8B-Instruct-GGUF/resolve/main/Meta-Llama-3.1-8B-Instruct-Q5_K_M.gguf"
+        MODEL_SHA256="14e10feba0c82a55da198dcd69d137206ad22d116a809926d27fa5f2398c69c7"
     elif [ "$1" = "phi-3-mini" ]; then
         MODEL_URL="https://huggingface.co/bartowski/Phi-3-mini-4k-instruct-GGUF/resolve/main/Phi-3-mini-4k-instruct-Q6_K.gguf"
         MODEL_SHA256="597a483b0e56360cb488d3f8a5ec0fd2c3a3eb44da7bb69020b79ba7c1f6ce85"
@@ -35,7 +38,7 @@ if [ "$#" -eq 1 ]; then
         MODEL_URL="https://huggingface.co/bartowski/gemma-2-27b-it-GGUF/resolve/main/gemma-2-27b-it-Q5_K_M.gguf"
         MODEL_SHA256="fbefa7ddf24b32dee231c40e0bdd55f9a3ef0e64c8559b0cb48b66cce66fe671"
     else
-        echo "$0 [llama-2-13b|mistral-7b|solar-10b|starling-7b|command-r|llama-3-8b|phi-3-mini|phi-3-medium|gemma-2-9b|gemma-2-27b]"
+        echo "$0 [llama-2-13b|mistral-7b|solar-10b|starling-7b|command-r|llama-3-8b|llama-3.1-8b|phi-3-mini|phi-3-medium|gemma-2-9b|gemma-2-27b]"
         exit 1
     fi
     MODEL_NAME=$(basename "$MODEL_URL")

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -2,46 +2,35 @@
 
 set -eu
 
+# model target, sha256 hash, and url
+MODEL_LIST=$(cat << EOF
+llama-2-13b ef36e090240040f97325758c1ad8e23f3801466a8eece3a9eac2d22d942f548a https://huggingface.co/TheBloke/Llama-2-13B-chat-GGUF/resolve/main/llama-2-13b-chat.Q5_K_M.gguf
+mistral-7b b85cdd596ddd76f3194047b9108a73c74d77ba04bef49255a50fc0cfbda83d32 https://huggingface.co/TheBloke/Mistral-7B-Instruct-v0.2-GGUF/resolve/main/mistral-7b-instruct-v0.2.Q5_K_M.gguf
+solar-10b 4ade240f5dcc253272158f3659a56f5b1da8405510707476d23a7df943aa35f7 https://huggingface.co/TheBloke/SOLAR-10.7B-Instruct-v1.0-GGUF/resolve/main/solar-10.7b-instruct-v1.0.Q5_K_M.gguf
+starling-7b c67b033bff47e7b8574491c6c296c094e819488d146aca1c6326c10257450b99 https://huggingface.co/bartowski/Starling-LM-7B-beta-GGUF/resolve/main/Starling-LM-7B-beta-Q5_K_M.gguf
+command-r 1a59aeb034b64e430d25bc9f2b29d9f2cc658af38670fae36226585603da8ecc https://huggingface.co/bartowski/c4ai-command-r-v01-GGUF/resolve/main/c4ai-command-r-v01-Q5_K_M.gguf
+llama-3-8b 16d824ee771e0e33b762bb3dc3232b972ac8dce4d2d449128fca5081962a1a9e https://huggingface.co/bartowski/Meta-Llama-3-8B-Instruct-GGUF/resolve/main/Meta-Llama-3-8B-Instruct-Q5_K_M.gguf
+llama-3.1-8b 14e10feba0c82a55da198dcd69d137206ad22d116a809926d27fa5f2398c69c7 https://huggingface.co/bartowski/Meta-Llama-3.1-8B-Instruct-GGUF/resolve/main/Meta-Llama-3.1-8B-Instruct-Q5_K_M.gguf
+phi-3-mini 597a483b0e56360cb488d3f8a5ec0fd2c3a3eb44da7bb69020b79ba7c1f6ce85 https://huggingface.co/bartowski/Phi-3-mini-4k-instruct-GGUF/resolve/main/Phi-3-mini-4k-instruct-Q6_K.gguf
+phi-3-medium 5e9d850d6c899e7fdf39a19cdf6fecae225e0c5bb3d13d6f277cbda508a15f0c https://huggingface.co/bartowski/Phi-3-medium-4k-instruct-GGUF/resolve/main/Phi-3-medium-4k-instruct-Q5_K_M.gguf
+gemma-2-9b a4b0b55ce809a09baaefb789b0046ac77ecd502aba8aeb2ed63cc237d9f40ce7 https://huggingface.co/bartowski/gemma-2-9b-it-GGUF/resolve/main/gemma-2-9b-it-Q5_K_M.gguf
+gemma-2-27b fbefa7ddf24b32dee231c40e0bdd55f9a3ef0e64c8559b0cb48b66cce66fe671 https://huggingface.co/bartowski/gemma-2-27b-it-GGUF/resolve/main/gemma-2-27b-it-Q5_K_M.gguf
+EOF
+)
+
 # download model if specified as argument and exit
 if [ "$#" -eq 1 ]; then
-    if [ "$1" = "llama-2-13b" ]; then
-        MODEL_URL="https://huggingface.co/TheBloke/Llama-2-13B-chat-GGUF/resolve/main/llama-2-13b-chat.Q5_K_M.gguf"
-        MODEL_SHA256="ef36e090240040f97325758c1ad8e23f3801466a8eece3a9eac2d22d942f548a"
-    elif [ "$1" = "mistral-7b" ]; then
-        MODEL_URL="https://huggingface.co/TheBloke/Mistral-7B-Instruct-v0.2-GGUF/resolve/main/mistral-7b-instruct-v0.2.Q5_K_M.gguf"
-        MODEL_SHA256="b85cdd596ddd76f3194047b9108a73c74d77ba04bef49255a50fc0cfbda83d32"
-    elif [ "$1" = "solar-10b" ]; then
-        MODEL_URL="https://huggingface.co/TheBloke/SOLAR-10.7B-Instruct-v1.0-GGUF/resolve/main/solar-10.7b-instruct-v1.0.Q5_K_M.gguf"
-        MODEL_SHA256="4ade240f5dcc253272158f3659a56f5b1da8405510707476d23a7df943aa35f7"
-    elif [ "$1" = "starling-7b" ]; then
-        MODEL_URL="https://huggingface.co/bartowski/Starling-LM-7B-beta-GGUF/resolve/main/Starling-LM-7B-beta-Q5_K_M.gguf"
-        MODEL_SHA256="c67b033bff47e7b8574491c6c296c094e819488d146aca1c6326c10257450b99"
-    elif [ "$1" = "command-r" ]; then
-        MODEL_URL="https://huggingface.co/bartowski/c4ai-command-r-v01-GGUF/resolve/main/c4ai-command-r-v01-Q5_K_M.gguf"
-        MODEL_SHA256="1a59aeb034b64e430d25bc9f2b29d9f2cc658af38670fae36226585603da8ecc"
-    elif [ "$1" = "llama-3-8b" ]; then
-        MODEL_URL="https://huggingface.co/bartowski/Meta-Llama-3-8B-Instruct-GGUF/resolve/main/Meta-Llama-3-8B-Instruct-Q5_K_M.gguf"
-        MODEL_SHA256="16d824ee771e0e33b762bb3dc3232b972ac8dce4d2d449128fca5081962a1a9e"
-    elif [ "$1" = "llama-3.1-8b" ]; then
-        MODEL_URL="https://huggingface.co/bartowski/Meta-Llama-3.1-8B-Instruct-GGUF/resolve/main/Meta-Llama-3.1-8B-Instruct-Q5_K_M.gguf"
-        MODEL_SHA256="14e10feba0c82a55da198dcd69d137206ad22d116a809926d27fa5f2398c69c7"
-    elif [ "$1" = "phi-3-mini" ]; then
-        MODEL_URL="https://huggingface.co/bartowski/Phi-3-mini-4k-instruct-GGUF/resolve/main/Phi-3-mini-4k-instruct-Q6_K.gguf"
-        MODEL_SHA256="597a483b0e56360cb488d3f8a5ec0fd2c3a3eb44da7bb69020b79ba7c1f6ce85"
-    elif [ "$1" = "phi-3-medium" ]; then
-        MODEL_URL="https://huggingface.co/bartowski/Phi-3-medium-4k-instruct-GGUF/resolve/main/Phi-3-medium-4k-instruct-Q5_K_M.gguf"
-        MODEL_SHA256="5e9d850d6c899e7fdf39a19cdf6fecae225e0c5bb3d13d6f277cbda508a15f0c"
-    elif [ "$1" = "gemma-2-9b" ]; then
-        MODEL_URL="https://huggingface.co/bartowski/gemma-2-9b-it-GGUF/resolve/main/gemma-2-9b-it-Q5_K_M.gguf"
-        MODEL_SHA256="a4b0b55ce809a09baaefb789b0046ac77ecd502aba8aeb2ed63cc237d9f40ce7"
-    elif [ "$1" = "gemma-2-27b" ]; then
-        MODEL_URL="https://huggingface.co/bartowski/gemma-2-27b-it-GGUF/resolve/main/gemma-2-27b-it-Q5_K_M.gguf"
-        MODEL_SHA256="fbefa7ddf24b32dee231c40e0bdd55f9a3ef0e64c8559b0cb48b66cce66fe671"
-    else
-        echo "$0 [llama-2-13b|mistral-7b|solar-10b|starling-7b|command-r|llama-3-8b|llama-3.1-8b|phi-3-mini|phi-3-medium|gemma-2-9b|gemma-2-27b]"
+    MODEL_LINE=$(echo "$MODEL_LIST" | grep "$1" || true)
+
+    if [ -z "$MODEL_LINE" ]; then
+        echo "$MODEL_LIST" | awk '{print $1}' | tr '\n' '|' | sed 's/|$//' | xargs printf "$0 [%s]\n"
         exit 1
     fi
+
+    MODEL_SHA256=$(echo "$MODEL_LINE" | awk '{print $2}')
+    MODEL_URL=$(echo "$MODEL_LINE" | awk '{print $3}')
     MODEL_NAME=$(basename "$MODEL_URL")
+
     curl -LO "$MODEL_URL"
     echo "$MODEL_SHA256  $MODEL_NAME" | sha256sum -c -
     exit 0


### PR DESCRIPTION
Several improvements to more easily support newer models:

* Refactor `docker-entrypoint.sh`
* Simplify adding new models
* Add usage to `docker-entrypoint.sh`
* Update `nvidia/cuda` to version 12.5.1
* Add phi 3 medium, gemma 2 9b, gemma 2 27b, and llama 3.1 8b
* Improve documentation on model and model table

