### PR TITLE
Make Llama 3 8b the new default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [v1.11.0](https://github.com/fboulnois/llama-cpp-docker/compare/v1.10.0...v1.11.0) - 2025-01-20
+
+### Added
+
+* Switch to built-in environment variables
+* Switch to llama 3.1 8b as default
+
+### Changed
+
+* Only set target for default model
+
 ## [v1.10.0](https://github.com/fboulnois/llama-cpp-docker/compare/v1.9.0...v1.10.0) - 2025-01-04
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -20,5 +20,5 @@ endif
 down:
 	$(DOCKER) compose down
 
-%:
+llama-3-8b:
 	cd models && ../docker-entrypoint.sh $@

--- a/README.md
+++ b/README.md
@@ -38,10 +38,10 @@ for the complete list of server options.
 
 The [`docker-entrypoint.sh`](docker-entrypoint.sh) has targets for downloading
 popular models. Run `./docker-entrypoint.sh --help` to list available models.
-Download models by running `./docker-entrypoint.sh <model>` or `make <model>`
-where `<model>` is the name of the model. By default, these will download the
-`_Q5_K_M.gguf` versions of the models. These models are quantized to 5 bits
-which provide a good balance between speed and accuracy.
+Download models by running `./docker-entrypoint.sh <model>` where `<model>` is
+the name of the model. By default, these will download the `_Q5_K_M.gguf`
+versions of the models. These models are quantized to 5 bits which provide a
+good balance between speed and accuracy.
 
 Confused about which model to use? Below is a list of popular models, ranked by
 [ELO rating](https://en.wikipedia.org/wiki/Elo_rating_system). Generally, the

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ used instead.
 
 ```bash
 make build
-make llama-2-13b
+make llama-3-8b
 make up
 ```
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     environment:
       - GGML_CUDA_NO_PINNED=1
       - LLAMA_CTX_SIZE=2048
-      - LLAMA_MODEL=/models/llama-2-13b-chat.Q5_K_M.gguf
+      - LLAMA_MODEL=/models/Meta-Llama-3.1-8B-Instruct-Q5_K_M.gguf
       - LLAMA_N_GPU_LAYERS=99
     volumes:
       - ./models:/models

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,9 +4,9 @@ services:
     image: llama-cpp-docker
     environment:
       - GGML_CUDA_NO_PINNED=1
-      - LLAMA_CTX_SIZE=2048
-      - LLAMA_MODEL=/models/Meta-Llama-3.1-8B-Instruct-Q5_K_M.gguf
-      - LLAMA_N_GPU_LAYERS=99
+      - LLAMA_ARG_CTX_SIZE=2048
+      - LLAMA_ARG_MODEL=/models/Meta-Llama-3.1-8B-Instruct-Q5_K_M.gguf
+      - LLAMA_ARG_N_GPU_LAYERS=99
     volumes:
       - ./models:/models
     ports:

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -58,35 +58,13 @@ parse_args_download_model() {
 }
 
 set_default_env_vars() {
-  if [ -z ${LLAMA_HOST+x} ]; then
-    export LLAMA_HOST="0.0.0.0"
+  if [ -z ${LLAMA_ARG_HOST+x} ]; then
+    export LLAMA_ARG_HOST="0.0.0.0"
   fi
-  if [ -z ${LLAMA_MODEL+x} ]; then
-    export LLAMA_MODEL="/models/Meta-Llama-3.1-8B-Instruct-Q5_K_M.gguf"
-  fi
-}
-
-convert_llama_env_vars() {
-  LLAMA_ARGS=$(env | grep LLAMA_ | awk '{
-    # for each environment variable
-    for (n = 1; n <= NF; n++) {
-      # replace LLAMA_ prefix with --
-      sub("^LLAMA_", "--", $n)
-      # find first = and split into argument name and value
-      eq = index($n, "=")
-      s1 = tolower(substr($n, 1, eq - 1))
-      s2 = substr($n, eq + 1)
-      # replace _ with - in argument name
-      gsub("_", "-", s1)
-      # print argument name and value
-      print s1 " " s2
-    }
-  }')
 }
 
 parse_args_download_model "$@"
 set_default_env_vars
-convert_llama_env_vars
 
 set -x
-llama-server $LLAMA_ARGS
+llama-server

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -62,7 +62,7 @@ set_default_env_vars() {
     export LLAMA_HOST="0.0.0.0"
   fi
   if [ -z ${LLAMA_MODEL+x} ]; then
-    export LLAMA_MODEL="/models/llama-2-13b-chat.Q5_K_M.gguf"
+    export LLAMA_MODEL="/models/Meta-Llama-3.1-8B-Instruct-Q5_K_M.gguf"
   fi
 }
 


### PR DESCRIPTION
* Switch to Llama 3.1 8b as default
* Remove hacky pattern rule to download models and only set target for default model
* Switch to built-in environment variables