### PR TITLE
Feature updates 2025-04

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [v1.13.0](https://github.com/fboulnois/llama-cpp-docker/compare/v1.12.0...v1.13.0) - 2025-04-21
+
+### Changed
+
+* Split docker images into build and deploy
+
+### Fixed
+
+* Models are predownloaded so disable curl
+
 ## [v1.12.0](https://github.com/fboulnois/llama-cpp-docker/compare/v1.11.0...v1.12.0) - 2025-03-29
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update && apt-get install -y build-essential git libgomp1 cmake
 
 RUN git clone https://github.com/ggerganov/llama.cpp.git \
   && cd llama.cpp \
-  && cmake -B build -DGGML_CUDA=on -DBUILD_SHARED_LIBS=off \
+  && cmake -B build -DGGML_CUDA=on -DBUILD_SHARED_LIBS=off -DLLAMA_CURL=off \
   && cmake --build build --config Release -j
 
 FROM debian:12-slim AS env-deploy

--- a/Dockerfile-cpu
+++ b/Dockerfile-cpu
@@ -7,7 +7,7 @@ RUN apt-get update && apt-get install -y make git cmake clang-16 libomp-16-dev
 
 RUN git clone https://github.com/ggerganov/llama.cpp.git \
   && cd llama.cpp \
-  && CC=clang-16 CXX=clang++-16 cmake -B build -DBUILD_SHARED_LIBS=off \
+  && CC=clang-16 CXX=clang++-16 cmake -B build -DBUILD_SHARED_LIBS=off -DLLAMA_CURL=off \
   && cmake --build build --config Release -j
 
 FROM debian:12-slim AS env-deploy

--- a/Makefile
+++ b/Makefile
@@ -5,9 +5,11 @@ HAS_NVIDIA_GPU := $(shell which nvidia-smi >/dev/null && nvidia-smi --query --di
 
 build:
 ifdef HAS_NVIDIA_GPU
-	$(DOCKER) build . --tag $(DIRNAME)
+	$(DOCKER) build --target env-build  . --tag $(DIRNAME)-build
+	$(DOCKER) build --target env-deploy . --tag $(DIRNAME)
 else
-	$(DOCKER) build . --file Dockerfile-cpu --tag $(DIRNAME)
+	$(DOCKER) build --target env-build  . --file Dockerfile-cpu --tag $(DIRNAME)-build
+	$(DOCKER) build --target env-deploy . --file Dockerfile-cpu --tag $(DIRNAME)
 endif
 
 up:


### PR DESCRIPTION
* Models are downloaded using `docker-entrypoint.sh`, so curl dependency is unnecessary
* Build existing docker images separately for clarity and to avoid rebuilds when cache is cleared