### PR TITLE
Feature updates 2025-11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [v2.0.0](https://github.com/fboulnois/llama-cpp-docker/compare/v1.15.0...v2.0.0) - 2025-11-08
+
+### Added
+
+* Switch to using downloaded huggingface models
+* Switch to using huggingface model directly
+* Include static build of curl to download models
+* Update nvidia/cuda to 13.0.2
+
+### Changed
+
+* Remove rarely used models
+* Remove manual downloads of models
+* Enable pinned cuda memory by default
+
 ## [v1.15.0](https://github.com/fboulnois/llama-cpp-docker/compare/v1.14.0...v1.15.0) - 2025-10-23
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:12.9.1-devel-ubuntu24.04 AS env-build
+FROM nvidia/cuda:13.0.2-devel-ubuntu24.04 AS env-build
 
 WORKDIR /srv
 

--- a/Dockerfile-cpu
+++ b/Dockerfile-cpu
@@ -2,15 +2,41 @@ FROM ubuntu:24.04 AS env-build
 
 WORKDIR /srv
 
-# install build tools and clone and compile llama.cpp
-RUN apt-get update && apt-get install -y make git cmake clang-19 libomp-19-dev
+# install build tools and dependencies
+RUN apt-get update && apt-get install -y make git cmake clang-19 libomp-19-dev \
+  curl ca-certificates libssl-dev zlib1g-dev xz-utils
+
+ARG CC=clang-19
+ARG CXX=clang++-19
+ARG CURL_VERSION=8.16.0
+
+# build static libcurl for llama.cpp
+RUN curl -LO https://curl.se/download/curl-${CURL_VERSION}.tar.xz \
+  && tar -xf curl-${CURL_VERSION}.tar.xz \
+  && cd curl-${CURL_VERSION} \
+  && ./configure --prefix=/usr/local --disable-shared --enable-static \
+    --with-openssl --with-zlib --disable-manual \
+    --without-libpsl --without-nghttp2 --without-brotli --without-zstd \
+    --disable-dict --disable-file --disable-ftp --disable-gopher \
+    --disable-imap --disable-ipfs --disable-ldap --disable-mqtt --disable-pop3 \
+    --disable-rtsp --disable-smb --disable-smtp --disable-telnet --disable-tftp \
+  && make -j"$(nproc)" \
+  && make install
+
+# clone and compile llama.cpp
+ENV PKG_CONFIG_PATH=/usr/local/lib/pkgconfig
+ENV LDFLAGS="-L/usr/local/lib -lssl -lcrypto -lz"
 
 RUN git clone https://github.com/ggerganov/llama.cpp.git \
   && cd llama.cpp \
-  && CC=clang-19 CXX=clang++-19 cmake -B build -DBUILD_SHARED_LIBS=off -DLLAMA_CURL=off \
+  && cmake -B build -DBUILD_SHARED_LIBS=off -DLLAMA_CURL=on \
   && cmake --build build --config Release -j
 
 FROM ubuntu:24.04 AS env-deploy
+
+# install gosu to run as nonroot and ca-certificates to download models
+RUN apt-get update && apt-get install -y gosu ca-certificates \
+  && rm -rf /var/lib/apt/lists/*
 
 # copy openmp libraries
 ENV LD_LIBRARY_PATH=/usr/local/lib
@@ -22,8 +48,6 @@ COPY --from=0 /srv/llama.cpp/build/bin/llama-server /usr/local/bin/llama-server
 
 # create llama user and set home directory
 RUN useradd --system --create-home llama
-
-USER llama
 
 WORKDIR /home/llama
 

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,3 @@ endif
 
 down:
 	$(DOCKER) compose down
-
-llama-3-8b:
-	cd models && ../docker-entrypoint.sh $@

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ After starting up the chat server will be available at `http://localhost:8080`.
 Options are specified as environment variables in the `docker-compose.yml` file. By default, the following options are set:
 
 * `LLAMA_ARG_CTX_SIZE`: The context size to use (default is 2048)
-* `LLAMA_ARG_MODEL`: The name of the model to use (default is `/models/Meta-Llama-3.1-8B-Instruct-Q5_K_M.gguf`)
+* `LLAMA_ARG_HF_REPO`: The repository and quantization of the HuggingFace model to use (default is `bartowski/Meta-Llama-3.1-8B-Instruct-GGUF:q5_k_m`)
 * `LLAMA_ARG_N_GPU_LAYERS`: The number of layers to run on the GPU (default is 99)
 
 See the [llama.cpp documentation](https://github.com/ggml-org/llama.cpp/tree/master/tools/server) for the complete list of server options.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Options are specified as environment variables in the `docker-compose.yml` file.
 * `LLAMA_ARG_MODEL`: The name of the model to use (default is `/models/Meta-Llama-3.1-8B-Instruct-Q5_K_M.gguf`)
 * `LLAMA_ARG_N_GPU_LAYERS`: The number of layers to run on the GPU (default is 99)
 
-See the [llama.cpp documentation](https://github.com/ggerganov/llama.cpp/tree/master/examples/server) for the complete list of server options.
+See the [llama.cpp documentation](https://github.com/ggml-org/llama.cpp/tree/master/tools/server) for the complete list of server options.
 
 ## Models
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ After starting up the chat server will be available at `http://localhost:8080`.
 
 Options are specified as environment variables in the `docker-compose.yml` file. By default, the following options are set:
 
-* `GGML_CUDA_NO_PINNED`: Disable pinned memory for compatability (default is 1)
 * `LLAMA_ARG_CTX_SIZE`: The context size to use (default is 2048)
 * `LLAMA_ARG_MODEL`: The name of the model to use (default is `/models/Meta-Llama-3.1-8B-Instruct-Q5_K_M.gguf`)
 * `LLAMA_ARG_N_GPU_LAYERS`: The number of layers to run on the GPU (default is 99)

--- a/README.md
+++ b/README.md
@@ -1,13 +1,10 @@
 # Llama.cpp in Docker
 
-Run [llama.cpp](https://github.com/ggerganov/llama.cpp) in a GPU accelerated
-Docker container.
+Run [llama.cpp](https://github.com/ggerganov/llama.cpp) in a GPU accelerated Docker container.
 
 ## Minimum requirements
 
-By default, the service requires a CUDA capable GPU with at least 8GB+ of VRAM. 
-If you don't have an Nvidia GPU with CUDA then the CPU version will be built and
-used instead.
+By default, the service requires a CUDA capable GPU with at least 8GB+ of VRAM. If you don't have an Nvidia GPU with CUDA then the CPU version will be built and used instead.
 
 ## Quickstart
 
@@ -21,29 +18,20 @@ After starting up the chat server will be available at `http://localhost:8080`.
 
 ## Options
 
-Options are specified as environment variables in the `docker-compose.yml` file.
-By default, the following options are set:
+Options are specified as environment variables in the `docker-compose.yml` file. By default, the following options are set:
 
 * `GGML_CUDA_NO_PINNED`: Disable pinned memory for compatability (default is 1)
 * `LLAMA_ARG_CTX_SIZE`: The context size to use (default is 2048)
 * `LLAMA_ARG_MODEL`: The name of the model to use (default is `/models/Meta-Llama-3.1-8B-Instruct-Q5_K_M.gguf`)
 * `LLAMA_ARG_N_GPU_LAYERS`: The number of layers to run on the GPU (default is 99)
 
-See the [llama.cpp documentation](https://github.com/ggerganov/llama.cpp/tree/master/examples/server)
-for the complete list of server options.
+See the [llama.cpp documentation](https://github.com/ggerganov/llama.cpp/tree/master/examples/server) for the complete list of server options.
 
 ## Models
 
-The [`docker-entrypoint.sh`](docker-entrypoint.sh) has targets for downloading
-popular models. Run `./docker-entrypoint.sh --help` to list available models.
-Download models by running `./docker-entrypoint.sh <model>` where `<model>` is
-the name of the model. By default, these will download the `_Q5_K_M.gguf`
-versions of the models. These models are quantized to 5 bits which provide a
-good balance between speed and accuracy.
+The [`docker-entrypoint.sh`](docker-entrypoint.sh) has targets for downloading popular models. Run `./docker-entrypoint.sh --help` to list available models. Download models by running `./docker-entrypoint.sh <model>` where `<model>` is the name of the model. By default, these will download the `_Q5_K_M.gguf` versions of the models. These models are quantized to 5 bits which provide a good balance between speed and accuracy.
 
-Confused about which model to use? Below is a list of popular models, ranked by
-[ELO rating](https://en.wikipedia.org/wiki/Elo_rating_system). Generally, the
-higher the ELO rating the better the model.
+Confused about which model to use? Below is a list of popular models, ranked by [ELO rating](https://en.wikipedia.org/wiki/Elo_rating_system). Generally, the higher the ELO rating the better the model.
 
 | Target | Model | Parameters | Size | [~ELO](https://chat.lmsys.org/?leaderboard) | Notes |
 | --- | --- | --- | --- | --- | --- |
@@ -54,5 +42,4 @@ higher the ELO rating the better the model.
 | phi-4-mini | [`phi-4-mini-instruct`](https://huggingface.co/bartowski/microsoft_Phi-4-mini-instruct-GGUF) | 4B | 2.85 GB | 1088++ | Microsoft's best tiny model |
 
 > [!NOTE]
-> Values with `+` are minimum estimates from previous versions of the model due
-> to missing data.
+> Values with `+` are minimum estimates from previous versions of the model due to missing data.

--- a/README.md
+++ b/README.md
@@ -28,17 +28,17 @@ See the [llama.cpp documentation](https://github.com/ggml-org/llama.cpp/tree/mas
 
 ## Models
 
-The [`docker-entrypoint.sh`](docker-entrypoint.sh) has targets for downloading popular models. Run `./docker-entrypoint.sh --help` to list available models. Download models by running `./docker-entrypoint.sh <model>` where `<model>` is the name of the model. By default, these will download the `_Q5_K_M.gguf` versions of the models. These models are quantized to 5 bits which provide a good balance between speed and accuracy.
+Use the `LLAMA_ARG_HF_REPO` environment variable to automatically download and use a model from HuggingFace. The format is `<huggingface-repository><:quant>` where `<:quant>` is optional and specifies the quantization to use. For example, to download a model from `https://huggingface.co/bartowski/Meta-Llama-3.1-8B-Instruct-GGUF` with no quantization, set the variable to `bartowski/Meta-Llama-3.1-8B-Instruct-GGUF`. To use the same model with `q5_k_m` quantization, set the variable to `bartowski/Meta-Llama-3.1-8B-Instruct-GGUF:q5_k_m`. Models must be in the GGUF format, which is the default format for `llama.cpp` models. Models quantized with `q5_k_m` are recommended for a good balance between speed and accuracy. To list popular models, run `./docker-entrypoint.sh --help`.
 
-Confused about which model to use? Below is a list of popular models, ranked by [ELO rating](https://en.wikipedia.org/wiki/Elo_rating_system). Generally, the higher the ELO rating the better the model.
+Confused about which model to use? Below is a list of top popular models, ranked by [ELO rating](https://en.wikipedia.org/wiki/Elo_rating_system). Generally, the higher the ELO rating the better the model. Set `LLAMA_ARG_HF_REPO` to the repository name to use a specific model.
 
-| Target | Model | Parameters | Size | [~ELO](https://chat.lmsys.org/?leaderboard) | Notes |
+| Model | Repository | Parameters | Q5_K_M Size | [~ELO](https://chat.lmsys.org/?leaderboard) | Notes |
 | --- | --- | --- | --- | --- | --- |
-| deepseek-r1-qwen-14b | [`deepseek-r1-distill-qwen-14b`](https://huggingface.co/bartowski/DeepSeek-R1-Distill-Qwen-14B-GGUF) | 14B | 10.5 GB | 1375 | The best small thinking model |
-| gemma-3-27b | [`gemma-3-27b-it`](https://huggingface.co/bartowski/google_gemma-3-27b-it-GGUF) | 27B | 19.27 GB | 1361 | Google's best medium model |
-| mistral-small-3 | [`mistral-small-3.2-24b-instruct`](https://huggingface.co/bartowski/mistralai_Mistral-Small-3.2-24B-Instruct-2506-GGUF) | 24B | 16.76 GB | 1273 | Mistral AI's best small model |
-| llama-3-8b | [`meta-llama-3.1-8b-instruct`](https://huggingface.co/bartowski/Meta-Llama-3.1-8B-Instruct-GGUF) | 8B | 5.73 GB | 1193 | Meta's best small model |
-| phi-4-mini | [`phi-4-mini-instruct`](https://huggingface.co/bartowski/microsoft_Phi-4-mini-instruct-GGUF) | 4B | 2.85 GB | 1088++ | Microsoft's best tiny model |
+| deepseek-r1-distill-qwen-14b | [`bartowski/DeepSeek-R1-Distill-Qwen-14B-GGUF`](https://huggingface.co/bartowski/DeepSeek-R1-Distill-Qwen-14B-GGUF) | 14B | 10.5 GB | 1375 | The best small thinking model |
+| gemma-3-27b | [`bartowski/google_gemma-3-27b-it-GGUF`](https://huggingface.co/bartowski/google_gemma-3-27b-it-GGUF) | 27B | 19.27 GB | 1361 | Google's best medium model |
+| mistral-small-3.2-24b | [`bartowski/mistralai_Mistral-Small-3.2-24B-Instruct-2506-GGUF`](https://huggingface.co/bartowski/mistralai_Mistral-Small-3.2-24B-Instruct-2506-GGUF) | 24B | 16.76 GB | 1273 | Mistral AI's best small model |
+| llama-3.1-8b | [`bartowski/Meta-Llama-3.1-8B-Instruct-GGUF`](https://huggingface.co/bartowski/Meta-Llama-3.1-8B-Instruct-GGUF) | 8B | 5.73 GB | 1193 | Meta's best small model |
+| phi-4-mini | [`bartowski/microsoft_Phi-4-mini-instruct-GGUF`](https://huggingface.co/bartowski/microsoft_Phi-4-mini-instruct-GGUF) | 4B | 2.85 GB | 1088++ | Microsoft's best tiny model |
 
 > [!NOTE]
 > Values with `+` are minimum estimates from previous versions of the model due to missing data.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ By default, the service requires a CUDA capable GPU with at least 8GB+ of VRAM. 
 
 ```bash
 make build
-make llama-3-8b
 make up
 ```
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     image: llama-cpp-docker
     environment:
       - LLAMA_ARG_CTX_SIZE=2048
-      - LLAMA_ARG_MODEL=/models/Meta-Llama-3.1-8B-Instruct-Q5_K_M.gguf
+      - LLAMA_ARG_HF_REPO=bartowski/Meta-Llama-3.1-8B-Instruct-GGUF:q5_k_m
       - LLAMA_ARG_N_GPU_LAYERS=99
     volumes:
       - ./models:/models

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,10 @@ services:
       - LLAMA_ARG_N_GPU_LAYERS=99
     volumes:
       - ./models:/models
+      - data:/home/llama/.cache
     ports:
       - target: 8080
         published: 8080
         mode: host
+volumes:
+  data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,6 @@ services:
   llama:
     image: llama-cpp-docker
     environment:
-      - GGML_CUDA_NO_PINNED=1
       - LLAMA_ARG_CTX_SIZE=2048
       - LLAMA_ARG_MODEL=/models/Meta-Llama-3.1-8B-Instruct-Q5_K_M.gguf
       - LLAMA_ARG_N_GPU_LAYERS=99

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,6 @@ services:
       - LLAMA_ARG_HF_REPO=bartowski/Meta-Llama-3.1-8B-Instruct-GGUF:q5_k_m
       - LLAMA_ARG_N_GPU_LAYERS=99
     volumes:
-      - ./models:/models
       - data:/home/llama/.cache
     ports:
       - target: 8080

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -70,8 +70,15 @@ set_default_env_vars() {
   fi
 }
 
+set_cache_permissions() {
+  UID=$(id -u llama)
+  chown -R "$UID:$UID" /home/llama/.cache
+  chmod 1777 /home/llama/.cache
+}
+
 parse_args_download_model "$@"
 set_default_env_vars
+set_cache_permissions
 
 set -x
-llama-server
+exec gosu "$UID:$UID" llama-server

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -10,9 +10,6 @@ https://huggingface.co/bartowski/Mistral-7B-Instruct-v0.3-GGUF
 https://huggingface.co/bartowski/Mistral-Small-Instruct-2409-GGUF
 https://huggingface.co/bartowski/mistralai_Mistral-Small-3.2-24B-Instruct-2506-GGUF
 https://huggingface.co/bartowski/Ministral-8B-Instruct-2410-GGUF
-https://huggingface.co/TheBloke/SOLAR-10.7B-Instruct-v1.0-GGUF
-https://huggingface.co/bartowski/Starling-LM-7B-beta-GGUF
-https://huggingface.co/bartowski/c4ai-command-r-08-2024-GGUF
 https://huggingface.co/bartowski/Phi-3-mini-4k-instruct-GGUF
 https://huggingface.co/bartowski/Phi-3-medium-4k-instruct-GGUF
 https://huggingface.co/bartowski/Phi-3.5-mini-instruct-GGUF

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -2,64 +2,50 @@
 
 set -eu
 
-# model target, sha256 hash, and url
+# model urls
 MODEL_LIST=$(cat << EOF
-llama-2-13b ef36e090240040f97325758c1ad8e23f3801466a8eece3a9eac2d22d942f548a https://huggingface.co/TheBloke/Llama-2-13B-chat-GGUF/resolve/main/llama-2-13b-chat.Q5_K_M.gguf
-llama-3-8b 14e10feba0c82a55da198dcd69d137206ad22d116a809926d27fa5f2398c69c7 https://huggingface.co/bartowski/Meta-Llama-3.1-8B-Instruct-GGUF/resolve/main/Meta-Llama-3.1-8B-Instruct-Q5_K_M.gguf
-mistral-7b 0374072546aaf1257d1e34610edb11b691730d8ef7d44b5629693a2dd8e8d472 https://huggingface.co/bartowski/Mistral-7B-Instruct-v0.3-GGUF/resolve/main/Mistral-7B-Instruct-v0.3-Q5_K_M.gguf
-mistral-small b84ae96c2b36975beb785f09579b411ea68a83f2eabd37bd17f6b64052e8cb75 https://huggingface.co/bartowski/Mistral-Small-Instruct-2409-GGUF/resolve/main/Mistral-Small-Instruct-2409-Q5_K_M.gguf
-mistral-small-3 c3313e3e8edfc76ffea18e42d94646a56868c57c64c6b0845d35adb3156a201f https://huggingface.co/bartowski/mistralai_Mistral-Small-3.2-24B-Instruct-2506-GGUF/resolve/main/mistralai_Mistral-Small-3.2-24B-Instruct-2506-Q5_K_M.gguf
-ministral-8b 190766d270e0e13a8ea2d1ff5bc2faae8cf5897736881bd1fd1698651cc82c8b https://huggingface.co/bartowski/Ministral-8B-Instruct-2410-GGUF/resolve/main/Ministral-8B-Instruct-2410-Q5_K_M.gguf
-solar-10b 4ade240f5dcc253272158f3659a56f5b1da8405510707476d23a7df943aa35f7 https://huggingface.co/TheBloke/SOLAR-10.7B-Instruct-v1.0-GGUF/resolve/main/solar-10.7b-instruct-v1.0.Q5_K_M.gguf
-starling-7b c67b033bff47e7b8574491c6c296c094e819488d146aca1c6326c10257450b99 https://huggingface.co/bartowski/Starling-LM-7B-beta-GGUF/resolve/main/Starling-LM-7B-beta-Q5_K_M.gguf
-command-r da705fbbfceaa128528cb9dd15dc1936adbb11e80d2ef504bf39bf8d0f521e3c https://huggingface.co/bartowski/c4ai-command-r-08-2024-GGUF/resolve/main/c4ai-command-r-08-2024-Q5_K_M.gguf
-phi-3-mini 597a483b0e56360cb488d3f8a5ec0fd2c3a3eb44da7bb69020b79ba7c1f6ce85 https://huggingface.co/bartowski/Phi-3-mini-4k-instruct-GGUF/resolve/main/Phi-3-mini-4k-instruct-Q6_K.gguf
-phi-3-medium 5e9d850d6c899e7fdf39a19cdf6fecae225e0c5bb3d13d6f277cbda508a15f0c https://huggingface.co/bartowski/Phi-3-medium-4k-instruct-GGUF/resolve/main/Phi-3-medium-4k-instruct-Q5_K_M.gguf
-phi-3.5-mini df76b3117fac9fbcce3456b386d0250cbfded9f2e6878207250124d1966e9192 https://huggingface.co/bartowski/Phi-3.5-mini-instruct-GGUF/blob/main/Phi-3.5-mini-instruct-Q6_K.gguf
-phi-4-mini 59dba927b98f39c26859aab7fb27d5f577666f8a5db38f0eccf3f207902ba23b https://huggingface.co/bartowski/microsoft_Phi-4-mini-instruct-GGUF/resolve/main/microsoft_Phi-4-mini-instruct-Q6_K.gguf
-gemma-2-9b a4b0b55ce809a09baaefb789b0046ac77ecd502aba8aeb2ed63cc237d9f40ce7 https://huggingface.co/bartowski/gemma-2-9b-it-GGUF/resolve/main/gemma-2-9b-it-Q5_K_M.gguf
-gemma-2-27b fbefa7ddf24b32dee231c40e0bdd55f9a3ef0e64c8559b0cb48b66cce66fe671 https://huggingface.co/bartowski/gemma-2-27b-it-GGUF/resolve/main/gemma-2-27b-it-Q5_K_M.gguf
-gemma-3-12b 13d44e37860489806f575deb0b219c6058c9421fe1982a9311a0e367c4e8f444 https://huggingface.co/bartowski/google_gemma-3-12b-it-GGUF/resolve/main/google_gemma-3-12b-it-Q5_K_M.gguf
-gemma-3-27b 7babc9bc281f07edae1cbfe519f61b12daa760b36be8ba53e72ddfdc9eceb846 https://huggingface.co/bartowski/google_gemma-3-27b-it-GGUF/resolve/main/google_gemma-3-27b-it-Q5_K_M.gguf
-qwen2.5-7b 2e998d7e181c8756c5ffc55231b9ee1cdc9d3acec4245d6e27d32bd8e738c474 https://huggingface.co/bartowski/Qwen2.5-7B-Instruct-GGUF/resolve/main/Qwen2.5-7B-Instruct-Q5_K_M.gguf
-qwen2.5-14b 48ad2dafedac636f62847f5338c356cd21f5cfa6b1e2c885360cb10c890b8cb2 https://huggingface.co/bartowski/Qwen2.5-14B-Instruct-GGUF/resolve/main/Qwen2.5-14B-Instruct-Q5_K_M.gguf
-qwen2.5-32b 371c9d50b4c2db96c7b6695b81a23c03c10a0ee780a8c3fe9193aac148febdaf https://huggingface.co/bartowski/Qwen2.5-32B-Instruct-GGUF/resolve/main/Qwen2.5-32B-Instruct-Q5_K_M.gguf
-deepseek-r1-qwen-8b 5842a7d03f76cf11a418447ef63f12750dc340430ac8a330a6faa8fe8ddc8040 https://huggingface.co/bartowski/deepseek-ai_DeepSeek-R1-0528-Qwen3-8B-GGUF/resolve/main/deepseek-ai_DeepSeek-R1-0528-Qwen3-8B-Q5_K_M.gguf
-deepseek-r1-qwen-14b 3eea644370914aebfff274dd8f5a790aaee42ba69a1ce09051eeaad0f05afd32 https://huggingface.co/bartowski/DeepSeek-R1-Distill-Qwen-14B-GGUF/resolve/main/DeepSeek-R1-Distill-Qwen-14B-Q5_K_M.gguf
-deepseek-r1-qwen-32b 9f345fb6721d413669afad82154b177cb45e333f49926e38c3586f01c37dfcca https://huggingface.co/bartowski/DeepSeek-R1-Distill-Qwen-32B-GGUF/resolve/main/DeepSeek-R1-Distill-Qwen-32B-Q5_K_M.gguf
+https://huggingface.co/TheBloke/Llama-2-13B-chat-GGUF
+https://huggingface.co/bartowski/Meta-Llama-3.1-8B-Instruct-GGUF
+https://huggingface.co/bartowski/Mistral-7B-Instruct-v0.3-GGUF
+https://huggingface.co/bartowski/Mistral-Small-Instruct-2409-GGUF
+https://huggingface.co/bartowski/mistralai_Mistral-Small-3.2-24B-Instruct-2506-GGUF
+https://huggingface.co/bartowski/Ministral-8B-Instruct-2410-GGUF
+https://huggingface.co/TheBloke/SOLAR-10.7B-Instruct-v1.0-GGUF
+https://huggingface.co/bartowski/Starling-LM-7B-beta-GGUF
+https://huggingface.co/bartowski/c4ai-command-r-08-2024-GGUF
+https://huggingface.co/bartowski/Phi-3-mini-4k-instruct-GGUF
+https://huggingface.co/bartowski/Phi-3-medium-4k-instruct-GGUF
+https://huggingface.co/bartowski/Phi-3.5-mini-instruct-GGUF
+https://huggingface.co/bartowski/microsoft_Phi-4-mini-instruct-GGUF
+https://huggingface.co/bartowski/gemma-2-9b-it-GGUF
+https://huggingface.co/bartowski/gemma-2-27b-it-GGUF
+https://huggingface.co/bartowski/google_gemma-3-12b-it-GGUF
+https://huggingface.co/bartowski/google_gemma-3-27b-it-GGUF
+https://huggingface.co/bartowski/Qwen2.5-7B-Instruct-GGUF
+https://huggingface.co/bartowski/Qwen2.5-14B-Instruct-GGUF
+https://huggingface.co/bartowski/Qwen2.5-32B-Instruct-GGUF
+https://huggingface.co/bartowski/deepseek-ai_DeepSeek-R1-0528-Qwen3-8B-GGUF
+https://huggingface.co/bartowski/DeepSeek-R1-Distill-Qwen-14B-GGUF
+https://huggingface.co/bartowski/DeepSeek-R1-Distill-Qwen-32B-GGUF
 EOF
 )
 
 usage() {
-  MODEL_NAMES=$(echo "$MODEL_LIST" | awk '{print "  " $1}' | sort)
+  MODEL_NAMES=$(echo "$MODEL_LIST" | sed 's|https://huggingface.co/||' | sort)
   cat << EOF
-Usage: $0 [MODEL]...
-Run llama-server or download a model and exit
+Set the LLAMA_ARG_HF_REPO environment variable in docker-compose.yml to
+automatically download the model from HuggingFace and use it.
 
-If no MODEL is provided, run llama-server with default settings.
-
-Available models to download:
+Popular models to download and use:
 
 $MODEL_NAMES
 
 EOF
 }
 
-parse_args_download_model() {
-  if [ "$#" -ge 1 ]; then
-    MODEL_LINE=$(echo "$MODEL_LIST" | grep "$1" || true)
-
-    if [ "$1" = "--help" ] || [ -z "$MODEL_LINE" ]; then
-      usage
-      exit 1
-    fi
-
-    MODEL_SHA256=$(echo "$MODEL_LINE" | awk '{print $2}')
-    MODEL_URL=$(echo "$MODEL_LINE" | awk '{print $3}')
-    MODEL_NAME=$(basename "$MODEL_URL")
-
-    curl -LO "$MODEL_URL"
-    echo "$MODEL_SHA256  $MODEL_NAME" | sha256sum -c -
+parse_args_check_docker() {
+  if [ ! -f /.dockerenv ] && [ ! -f /run/.containerenv ]; then
+    usage
     exit 0
   fi
 }
@@ -76,7 +62,7 @@ set_cache_permissions() {
   chmod 1777 /home/llama/.cache
 }
 
-parse_args_download_model "$@"
+parse_args_check_docker "$@"
 set_default_env_vars
 set_cache_permissions
 

--- a/models/.gitignore
+++ b/models/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore


### PR DESCRIPTION
- **BREAKING CHANGE**: Models are now automatically downloaded from HuggingFace using a static version of curl
- Update `nvidia/cuda` to version 13.0.2
- Update documentation for server options and HuggingFace models
