### PR TITLE
Model and curl updates 2025-11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [v2.1.0](https://github.com/fboulnois/llama-cpp-docker/compare/v2.0.0...v2.1.0) - 2025-11-11
+
+### Added
+
+* Update curl to 8.17.0
+* Add qwen3 and magistral models
+
 ## [v2.0.0](https://github.com/fboulnois/llama-cpp-docker/compare/v1.15.0...v2.0.0) - 2025-11-08
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update && apt-get install -y make git cmake clang-19 libomp-19-dev \
 
 ARG CC=clang-19
 ARG CXX=clang++-19
-ARG CURL_VERSION=8.16.0
+ARG CURL_VERSION=8.17.0
 
 # build static libcurl for llama.cpp
 RUN curl -LO https://curl.se/download/curl-${CURL_VERSION}.tar.xz \

--- a/Dockerfile-cpu
+++ b/Dockerfile-cpu
@@ -8,7 +8,7 @@ RUN apt-get update && apt-get install -y make git cmake clang-19 libomp-19-dev \
 
 ARG CC=clang-19
 ARG CXX=clang++-19
-ARG CURL_VERSION=8.16.0
+ARG CURL_VERSION=8.17.0
 
 # build static libcurl for llama.cpp
 RUN curl -LO https://curl.se/download/curl-${CURL_VERSION}.tar.xz \

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -9,6 +9,7 @@ https://huggingface.co/bartowski/Meta-Llama-3.1-8B-Instruct-GGUF
 https://huggingface.co/bartowski/Mistral-7B-Instruct-v0.3-GGUF
 https://huggingface.co/bartowski/Mistral-Small-Instruct-2409-GGUF
 https://huggingface.co/bartowski/mistralai_Mistral-Small-3.2-24B-Instruct-2506-GGUF
+https://huggingface.co/bartowski/mistralai_Magistral-Small-2509-GGUF
 https://huggingface.co/bartowski/Ministral-8B-Instruct-2410-GGUF
 https://huggingface.co/bartowski/Phi-3-mini-4k-instruct-GGUF
 https://huggingface.co/bartowski/Phi-3-medium-4k-instruct-GGUF
@@ -21,7 +22,12 @@ https://huggingface.co/bartowski/google_gemma-3-27b-it-GGUF
 https://huggingface.co/bartowski/Qwen2.5-7B-Instruct-GGUF
 https://huggingface.co/bartowski/Qwen2.5-14B-Instruct-GGUF
 https://huggingface.co/bartowski/Qwen2.5-32B-Instruct-GGUF
+https://huggingface.co/bartowski/Qwen_Qwen3-4B-Instruct-2507-GGUF
+https://huggingface.co/bartowski/Qwen_Qwen3-30B-A3B-Thinking-2507-GGUF
+https://huggingface.co/bartowski/Qwen_Qwen3-VL-8B-Instruct-GGUF
+https://huggingface.co/bartowski/Qwen_Qwen3-VL-30B-A3B-Thinking-GGUF
 https://huggingface.co/bartowski/deepseek-ai_DeepSeek-R1-0528-Qwen3-8B-GGUF
+https://huggingface.co/bartowski/DeepSeek-R1-Distill-Qwen-7B-GGUF
 https://huggingface.co/bartowski/DeepSeek-R1-Distill-Qwen-14B-GGUF
 https://huggingface.co/bartowski/DeepSeek-R1-Distill-Qwen-32B-GGUF
 EOF


### PR DESCRIPTION
- Add popular models: Qwen3 and Magistral
- Update curl to 8.17.0