### PR TITLE
Refresh model list 2025-11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [v2.1.1](https://github.com/fboulnois/llama-cpp-docker/compare/v2.1.0...v2.1.1) - 2025-11-30
+
+### Changed
+
+* Refresh model list
+
 ## [v2.1.0](https://github.com/fboulnois/llama-cpp-docker/compare/v2.0.0...v2.1.0) - 2025-11-11
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -37,11 +37,12 @@ Confused about which model to use? Below is a list of top popular models, ranked
 
 | Model | Repository | Parameters | Q5_K_M Size | [~ELO](https://lmarena.ai/leaderboard) | Notes |
 | --- | --- | --- | --- | --- | --- |
-| deepseek-r1-distill-qwen-14b | [`bartowski/DeepSeek-R1-Distill-Qwen-14B-GGUF`](https://huggingface.co/bartowski/DeepSeek-R1-Distill-Qwen-14B-GGUF) | 14B | 10.5 GB | 1375 | The best small thinking model |
-| gemma-3-27b | [`bartowski/google_gemma-3-27b-it-GGUF`](https://huggingface.co/bartowski/google_gemma-3-27b-it-GGUF) | 27B | 19.27 GB | 1361 | Google's best medium model |
-| mistral-small-3.2-24b | [`bartowski/mistralai_Mistral-Small-3.2-24B-Instruct-2506-GGUF`](https://huggingface.co/bartowski/mistralai_Mistral-Small-3.2-24B-Instruct-2506-GGUF) | 24B | 16.76 GB | 1273 | Mistral AI's best small model |
-| llama-3.1-8b | [`bartowski/Meta-Llama-3.1-8B-Instruct-GGUF`](https://huggingface.co/bartowski/Meta-Llama-3.1-8B-Instruct-GGUF) | 8B | 5.73 GB | 1193 | Meta's best small model |
-| phi-4-mini | [`bartowski/microsoft_Phi-4-mini-instruct-GGUF`](https://huggingface.co/bartowski/microsoft_Phi-4-mini-instruct-GGUF) | 4B | 2.85 GB | 1088++ | Microsoft's best tiny model |
+| qwen3-30b-a3b-instruct-2507 | [`bartowski/Qwen_Qwen3-30B-A3B-Instruct-2507-GGUF`](https://huggingface.co/bartowski/Qwen_Qwen3-30B-A3B-Instruct-2507-GGUF) | 30B | 21.74 GB | 1437 | Qwen's best medium model |
+| deepseek-r1-distill-qwen-14b | [`bartowski/DeepSeek-R1-Distill-Qwen-14B-GGUF`](https://huggingface.co/bartowski/DeepSeek-R1-Distill-Qwen-14B-GGUF) | 14B | 10.5 GB | 1375 | Deepseek's best small thinking model |
+| gemma-3-27b | [`bartowski/google_gemma-3-27b-it-GGUF`](https://huggingface.co/bartowski/google_gemma-3-27b-it-GGUF) | 27B | 19.27 GB | 1365 | Google's best medium model |
+| mistral-small-3.2-24b | [`bartowski/mistralai_Mistral-Small-3.2-24B-Instruct-2506-GGUF`](https://huggingface.co/bartowski/mistralai_Mistral-Small-3.2-24B-Instruct-2506-GGUF) | 24B | 16.76 GB | 1354 | Mistral AI's best small model |
+| llama-3.1-8b | [`bartowski/Meta-Llama-3.1-8B-Instruct-GGUF`](https://huggingface.co/bartowski/Meta-Llama-3.1-8B-Instruct-GGUF) | 8B | 5.73 GB | 1211 | Meta's best small model |
+| phi-4-mini | [`bartowski/microsoft_Phi-4-mini-instruct-GGUF`](https://huggingface.co/bartowski/microsoft_Phi-4-mini-instruct-GGUF) | 4B | 2.85 GB | 1198++ | Microsoft's best tiny model |
 
 > [!NOTE]
 > Values with `+` are minimum estimates from previous versions of the model due to missing data.

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -6,25 +6,18 @@ set -eu
 MODEL_LIST=$(cat << EOF
 https://huggingface.co/TheBloke/Llama-2-13B-chat-GGUF
 https://huggingface.co/bartowski/Meta-Llama-3.1-8B-Instruct-GGUF
-https://huggingface.co/bartowski/Mistral-7B-Instruct-v0.3-GGUF
-https://huggingface.co/bartowski/Mistral-Small-Instruct-2409-GGUF
 https://huggingface.co/bartowski/mistralai_Mistral-Small-3.2-24B-Instruct-2506-GGUF
 https://huggingface.co/bartowski/mistralai_Magistral-Small-2509-GGUF
 https://huggingface.co/bartowski/Ministral-8B-Instruct-2410-GGUF
-https://huggingface.co/bartowski/Phi-3-mini-4k-instruct-GGUF
-https://huggingface.co/bartowski/Phi-3-medium-4k-instruct-GGUF
-https://huggingface.co/bartowski/Phi-3.5-mini-instruct-GGUF
 https://huggingface.co/bartowski/microsoft_Phi-4-mini-instruct-GGUF
-https://huggingface.co/bartowski/gemma-2-9b-it-GGUF
-https://huggingface.co/bartowski/gemma-2-27b-it-GGUF
 https://huggingface.co/bartowski/google_gemma-3-12b-it-GGUF
 https://huggingface.co/bartowski/google_gemma-3-27b-it-GGUF
-https://huggingface.co/bartowski/Qwen2.5-7B-Instruct-GGUF
-https://huggingface.co/bartowski/Qwen2.5-14B-Instruct-GGUF
-https://huggingface.co/bartowski/Qwen2.5-32B-Instruct-GGUF
-https://huggingface.co/bartowski/Qwen_Qwen3-4B-Instruct-2507-GGUF
-https://huggingface.co/bartowski/Qwen_Qwen3-30B-A3B-Thinking-2507-GGUF
-https://huggingface.co/bartowski/Qwen_Qwen3-VL-8B-Instruct-GGUF
+https://huggingface.co/bartowski/Qwen_Qwen3-4B-GGUF
+https://huggingface.co/bartowski/Qwen_Qwen3-8B-GGUF
+https://huggingface.co/bartowski/Qwen_Qwen3-14B-GGUF
+https://huggingface.co/bartowski/Qwen_Qwen3-30B-A3B-GGUF
+https://huggingface.co/bartowski/Qwen_Qwen3-30B-A3B-Instruct-2507-GGUF
+https://huggingface.co/bartowski/Qwen_Qwen3-VL-30B-A3B-Instruct-GGUF
 https://huggingface.co/bartowski/Qwen_Qwen3-VL-30B-A3B-Thinking-GGUF
 https://huggingface.co/bartowski/deepseek-ai_DeepSeek-R1-0528-Qwen3-8B-GGUF
 https://huggingface.co/bartowski/DeepSeek-R1-Distill-Qwen-7B-GGUF
@@ -37,7 +30,7 @@ usage() {
   MODEL_NAMES=$(echo "$MODEL_LIST" | sed 's|https://huggingface.co/||' | sort)
   cat << EOF
 Set the LLAMA_ARG_HF_REPO environment variable in docker-compose.yml to
-automatically download the model from HuggingFace and use it.
+automatically download and use the model from HuggingFace.
 
 Popular models to download and use:
 


### PR DESCRIPTION
* Remove old models and add Qwen 3 derivatives
* Update README model ELO scores and include Qwen 3
